### PR TITLE
Require go 1.21 instead of 1.21.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/rrivera/identicon
 
-go 1.21.5
+go 1.21


### PR DESCRIPTION
Hi.

It would be nice not to specify the patch in the requirements for backwards compatibility.